### PR TITLE
stylelint-ember-scoped-css: Consider :root to be scoped

### DIFF
--- a/stylelint-ember-scoped-css/src/rules/no-unscoped-selectors/index.js
+++ b/stylelint-ember-scoped-css/src/rules/no-unscoped-selectors/index.js
@@ -96,7 +96,7 @@ function isScopedSelector(selectorNode) {
 function isScopedFunctionalPseudo(pseudoNode) {
   const name = pseudoNode.value;
 
-  if (name === ':global') {
+  if (name === ':global' || name === ':root') {
     return true;
   }
 

--- a/stylelint-ember-scoped-css/src/rules/no-unscoped-selectors/index.test.ts
+++ b/stylelint-ember-scoped-css/src/rules/no-unscoped-selectors/index.test.ts
@@ -11,10 +11,13 @@ testRule({
     { code: '[attr] .class {}' },
     { code: '[attr] tag {}' },
     { code: ':has(.class) {}' },
+    { code: ':has(.class, tag) {}' },
     { code: ':has(tag) {}' },
     { code: ':is(.class) {}' },
+    { code: ':is(.class, tag) {}' },
     { code: ':is(tag) {}' },
     { code: ':where(.class) {}' },
+    { code: ':where(.class, tag) {}' },
     { code: ':where(tag) {}' },
 
     // Global
@@ -24,7 +27,8 @@ testRule({
     { code: '.foo :global([bar]) {}' },
     { code: ':global(.x) [attr] {}' },
     { code: '[attr] :global(.y) {}' },
-    { code: '.foo:is(.a, [attr]) {}' },
+    { code: ':root {}' },
+    { code: ':root[attr] {}' },
 
     // At rules
     { code: '@keyframes spin { 0% {} 100% {} }' },


### PR DESCRIPTION
Consider :root to be scoped. If the dev uses this pseudo then they're intentionally intending to target the root element.